### PR TITLE
Update ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,6 +4,6 @@ defined('TYPO3_MODE') || die();
 
 call_user_func(function ($extensionKey) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
-        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . 'Configuration/TypoScript/Extbase/setup.typoscrript">'
+        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/TypoScript/Extbase/setup.typoscrript">'
     );
 }, 'static_info_tables_ro');


### PR DESCRIPTION
Fixes the following TYPO3 error:
Errors and warnings
Warning : File "EXT:static_info_tables_roConfiguration/TypoScript/Extbase/setup.typoscrript" was not found. Show details 

Compare:
https://codeberg.org/sjbr/static-info-tables/src/branch/master/ext_localconf.php Line 101